### PR TITLE
Set minimum due date to today in TaskModal and initialize due date in…

### DIFF
--- a/src/components/dashboard/TaskModal.vue
+++ b/src/components/dashboard/TaskModal.vue
@@ -54,7 +54,7 @@
             <label class="block text-sm font-medium text-gray-700 mb-1">Due Date</label>
             <input :value="taskForm.due_date"
               @input="$emit('update:taskForm', { ...taskForm, due_date: ($event.target as HTMLInputElement).value })"
-              type="date" required
+              type="date" required :min="todayDate"
               class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent" />
           </div>
 
@@ -77,6 +77,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Button } from '@/components/ui/button'
 import type { Category } from '@/data/dummyData'
 
@@ -100,4 +101,10 @@ defineEmits<{
   addCategory: []
   'update:taskForm': [value: TaskForm]
 }>()
+
+// Get today's date in YYYY-MM-DD format for the min attribute
+const todayDate = computed(() => {
+  const today = new Date()
+  return today.toISOString().split('T')[0]
+})
 </script>

--- a/src/views/dashboard/DashboardView.vue
+++ b/src/views/dashboard/DashboardView.vue
@@ -269,11 +269,16 @@ const fetchCategories = async () => {
 const openCreateModal = () => {
   isEditing.value = false
   editingTaskId.value = null
+
+  // Set default due date to today
+  const today = new Date()
+  const todayString = today.toISOString().split('T')[0]
+
   taskForm.value = {
     title: '',
     description: '',
     category_id: '',
-    due_date: ''
+    due_date: todayString
   }
   showModal.value = true
 }


### PR DESCRIPTION
This pull request improves the user experience for task creation by ensuring that the due date cannot be set to a past date and defaults to today when creating a new task. The most important changes are grouped below by theme.

**User Input Validation & Defaults**

* The `due_date` input field in `TaskModal.vue` now uses the `min` attribute set to today's date, preventing users from selecting a past date.
* When opening the task creation modal in `DashboardView.vue`, the default `due_date` is now set to today, streamlining the task creation process.

**Code Enhancements**

* Added a computed property `todayDate` in `TaskModal.vue` to dynamically generate today's date in the required format for the date input.
* Imported `computed` from Vue to support the new computed property.… DashboardView