### PR TITLE
Issue:

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- Routes work locally but fail with 404 NOT_FOUND on Vercel deployment
- Page refreshes and direct URL access cause server-side 404 errors
- Vercel tries to find physical files for client-side routes

Solution:
- Add vercel.json with rewrite rules to serve index.html for all routes
- Enables proper SPA behavior where Vue Router handles client-side routing
- Fixes 404 errors on refresh and direct route access in production"